### PR TITLE
Add PTO Tracking Feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "money-bae"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "money-bae"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/migrations/2025-12-14-152620-0000_create_ptos/down.sql
+++ b/migrations/2025-12-14-152620-0000_create_ptos/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE ptos;

--- a/migrations/2025-12-14-152620-0000_create_ptos/up.sql
+++ b/migrations/2025-12-14-152620-0000_create_ptos/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ptos (
+    id SERIAL PRIMARY KEY,
+    year INTEGER NOT NULL UNIQUE,
+    prev_year_hours NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    available_hours NUMERIC(10, 2) NOT NULL,
+    hours_planned NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    hours_used NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    hours_remaining NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    rollover_hours BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/migrations/2025-12-14-152733-0000_create_pto_plan/down.sql
+++ b/migrations/2025-12-14-152733-0000_create_pto_plan/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE pto_plan;

--- a/migrations/2025-12-14-152733-0000_create_pto_plan/up.sql
+++ b/migrations/2025-12-14-152733-0000_create_pto_plan/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE pto_plan (
+    id SERIAL PRIMARY KEY,
+    pto_id INTEGER NOT NULL REFERENCES ptos(id) ON DELETE CASCADE,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    name VARCHAR NOT NULL,
+    description TEXT,
+    hours NUMERIC(10, 2) NOT NULL,
+    status VARCHAR NOT NULL DEFAULT 'Planned',
+    custom_hours BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/migrations/2025-12-14-153457-0000_create_holiday_hours/down.sql
+++ b/migrations/2025-12-14-153457-0000_create_holiday_hours/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE holiday_hours;

--- a/migrations/2025-12-14-153457-0000_create_holiday_hours/up.sql
+++ b/migrations/2025-12-14-153457-0000_create_holiday_hours/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE holiday_hours (
+    id SERIAL PRIMARY KEY,
+    pto_id INTEGER NOT NULL REFERENCES ptos(id) ON DELETE CASCADE,
+    date DATE NOT NULL,
+    name VARCHAR NOT NULL,
+    hours NUMERIC(10, 2) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/migrations/2025-12-15-062148-0000_update_pto_hours_triggers/down.sql
+++ b/migrations/2025-12-15-062148-0000_update_pto_hours_triggers/down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS pto_plan_after_insert ON pto_plan;
+DROP TRIGGER IF EXISTS pto_plan_after_update ON pto_plan;
+DROP TRIGGER IF EXISTS pto_plan_after_delete ON pto_plan;
+DROP FUNCTION IF EXISTS update_pto_hours();

--- a/migrations/2025-12-15-062148-0000_update_pto_hours_triggers/up.sql
+++ b/migrations/2025-12-15-062148-0000_update_pto_hours_triggers/up.sql
@@ -1,0 +1,47 @@
+-- Function to update PTO hours aggregates
+CREATE OR REPLACE FUNCTION update_pto_hours() RETURNS TRIGGER AS $$
+BEGIN
+    -- Update hours_planned and hours_remaining for the affected PTO
+    UPDATE ptos
+    SET 
+        hours_planned = (
+            SELECT COALESCE(SUM(hours), 0)
+            FROM pto_plan
+            WHERE pto_id = COALESCE(NEW.pto_id, OLD.pto_id)
+            AND status IN ('Planned', 'Requested', 'Approved')
+        ),
+        hours_used = (
+            SELECT COALESCE(SUM(hours), 0)
+            FROM pto_plan
+            WHERE pto_id = COALESCE(NEW.pto_id, OLD.pto_id)
+            AND status = 'Completed'
+        ),
+        hours_remaining = available_hours + prev_year_hours - (
+            SELECT COALESCE(SUM(hours), 0)
+            FROM pto_plan
+            WHERE pto_id = COALESCE(NEW.pto_id, OLD.pto_id)
+            AND status = 'Completed'
+        )
+    WHERE id = COALESCE(NEW.pto_id, OLD.pto_id);
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on INSERT
+CREATE TRIGGER pto_plan_after_insert
+AFTER INSERT ON pto_plan
+FOR EACH ROW
+EXECUTE FUNCTION update_pto_hours();
+
+-- Trigger on UPDATE
+CREATE TRIGGER pto_plan_after_update
+AFTER UPDATE ON pto_plan
+FOR EACH ROW
+EXECUTE FUNCTION update_pto_hours();
+
+-- Trigger on DELETE
+CREATE TRIGGER pto_plan_after_delete
+AFTER DELETE ON pto_plan
+FOR EACH ROW
+EXECUTE FUNCTION update_pto_hours();

--- a/src/common_layout.rs
+++ b/src/common_layout.rs
@@ -11,7 +11,7 @@ pub fn create_screen<V: View>(title: &str, content: V, footer_hint: &str) -> imp
 
 /// Standard footer hints
 pub fn standard_footer() -> String {
-    "q:Quit | h:Home | i:Income | b:Bills | l:Ledger".to_string()
+    "q:Quit | h:Home | i:Income | b:Bills | l:Ledger | p:PTO".to_string()
 }
 
 pub fn view_footer() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ mod ledger_table;
 mod ledger_detail;
 mod common_layout;
 mod ui_helpers;
+mod pto_logic;
+mod pto_table;
+mod pto_detail;
 
 use cursive::Cursive;
 use cursive::theme::{BorderStyle, Palette};
@@ -120,6 +123,7 @@ fn main() {
     siv.add_global_callback('i', |s| show_income_table(s));
     siv.add_global_callback('b', |s| show_bill_table(s));
     siv.add_global_callback('l', |s| show_ledger_table(s));
+    siv.add_global_callback('p', |s| show_pto_view(s));
 
 
     let main_menu = common_layout::create_screen(
@@ -149,6 +153,11 @@ fn show_ledger_table(siv: &mut Cursive) {
     let ledger_table = ledger_table::LedgerTableView::new();
 
     ledger_table.add_table(siv);
+}
+
+fn show_pto_view(siv: &mut Cursive) {
+    siv.pop_layer();
+    pto_table::show_pto_table_view(siv);
 }
 
 fn clear(siv: &mut Cursive){

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,55 @@
 use chrono::NaiveDate;
 use diesel::prelude::*;
 use bigdecimal::BigDecimal;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtoStatus {
+    Planned,
+    Requested,
+    Approved,
+    Completed,
+}
+
+impl PtoStatus {
+    pub fn all() -> Vec<PtoStatus> {
+        vec![
+            PtoStatus::Planned,
+            PtoStatus::Requested,
+            PtoStatus::Approved,
+            PtoStatus::Completed,
+        ]
+    }
+}
+
+impl fmt::Display for PtoStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PtoStatus::Planned => write!(f, "Planned"),
+            PtoStatus::Requested => write!(f, "Requested"),
+            PtoStatus::Approved => write!(f, "Approved"),
+            PtoStatus::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+impl From<String> for PtoStatus {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "Requested" => PtoStatus::Requested,
+            "Approved" => PtoStatus::Approved,
+            "Completed" => PtoStatus::Completed,
+            _ => PtoStatus::Planned,
+        }
+    }
+}
+
+impl From<PtoStatus> for String {
+    fn from(status: PtoStatus) -> Self {
+        status.to_string()
+    }
+}
+
 
 #[derive(Queryable, Selectable, Clone, Debug)]
 #[diesel(table_name = crate::schema::incomes)]
@@ -85,4 +134,76 @@ pub struct NewLedgerBill {
     pub amount: BigDecimal,
     pub due_day: Option<NaiveDate>,
     pub is_payed: bool,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug)]
+#[diesel(table_name = crate::schema::ptos)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct Pto {
+    pub id: i32,
+    pub year: i32,
+    pub prev_year_hours: BigDecimal,
+    pub available_hours: BigDecimal,
+    pub hours_planned: BigDecimal,
+    pub hours_used: BigDecimal,
+    pub hours_remaining: BigDecimal,
+    pub rollover_hours: bool,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::ptos)]
+pub struct NewPto {
+    pub year: i32,
+    pub available_hours: BigDecimal,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug)]
+#[diesel(table_name = crate::schema::pto_plan)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct PtoPlan {
+    pub id: i32,
+    pub pto_id: i32,
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub name: String,
+    pub description: Option<String>,
+    pub hours: BigDecimal,
+    pub status: String,
+    pub custom_hours: bool,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::pto_plan)]
+pub struct NewPtoPlan {
+    pub pto_id: i32,
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub name: String,
+    pub description: Option<String>,
+    pub hours: BigDecimal,
+    pub status: String,
+    pub custom_hours: bool,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug)]
+#[diesel(table_name = crate::schema::holiday_hours)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct HolidayHours {
+    pub id: i32,
+    pub pto_id: i32,
+    pub date: NaiveDate,
+    pub name: String,
+    pub hours: BigDecimal,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::holiday_hours)]
+pub struct NewHolidayHours {
+    pub pto_id: i32,
+    pub date: NaiveDate,
+    pub name: String,
+    pub hours: BigDecimal,
 }

--- a/src/pto_detail.rs
+++ b/src/pto_detail.rs
@@ -1,0 +1,609 @@
+use std::cmp::Ordering;
+use bigdecimal::BigDecimal;
+use chrono::{Datelike, NaiveDate};
+use cursive::Cursive;
+use cursive::traits::*;
+use cursive::views::{Button, Dialog, EditView, LinearLayout, Panel, SelectView, TextView};
+use cursive_table_view::{TableView, TableViewItem};
+use diesel::prelude::*;
+
+use crate::models;
+use crate::schema;
+use crate::db::establish_connection;
+use crate::ui_helpers::toggle_buttons_visible;
+
+fn get_default_date(year: i32) -> String {
+    format!("01/01/{}", year)
+}
+
+fn calculate_or_custom_hours(
+    hours_str: &str,
+    start_date: NaiveDate,
+    end_date: NaiveDate,
+    pto_id: i32
+) -> (BigDecimal, bool) {
+    if hours_str.trim().is_empty() {
+        // Auto-calculate: load holidays for this PTO
+        let mut conn = establish_connection();
+        let holidays = schema::holiday_hours::table
+            .filter(schema::holiday_hours::pto_id.eq(pto_id))
+            .load::<models::HolidayHours>(&mut conn)
+            .expect("Error loading holidays");
+        
+        let holiday_tuples: Vec<(chrono::NaiveDate, BigDecimal)> = holidays
+            .into_iter()
+            .map(|h| (h.date, h.hours))
+            .collect();
+        
+        (crate::pto_logic::calculate_pto_hours(start_date, end_date, &holiday_tuples), false)
+    } else {
+        // Use custom hours provided
+        (BigDecimal::parse_bytes(hours_str.as_bytes(), 10).unwrap_or_default(), true)
+    }
+}
+
+fn parse_date_or_show_error(siv: &mut Cursive, date_str: &str) -> Option<NaiveDate> {
+    match NaiveDate::parse_from_str(date_str, "%m/%d/%Y") {
+        Ok(d) => Some(d),
+        Err(_) => {
+            siv.add_layer(Dialog::info("Invalid date format. Use MM/DD/YYYY"));
+            None
+        }
+    }
+}
+
+const HOLIDAY_EDIT_BUTTON: &str = "holiday_edit_button";
+const HOLIDAY_DELETE_BUTTON: &str = "holiday_delete_button";
+const HOLIDAY_TOGGLE_BUTTONS: &[&str] = &[HOLIDAY_EDIT_BUTTON, HOLIDAY_DELETE_BUTTON];
+
+const PLAN_EDIT_BUTTON: &str = "plan_edit_button";
+const PLAN_DELETE_BUTTON: &str = "plan_delete_button";
+const PLAN_VIEW_DESC_BUTTON: &str = "plan_view_desc_button";
+const PLAN_TOGGLE_BUTTONS: &[&str] = &[PLAN_EDIT_BUTTON, PLAN_DELETE_BUTTON, PLAN_VIEW_DESC_BUTTON];
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+enum HolidayColumn {
+    Date,
+    Name,
+    Hours,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+enum PlanColumn {
+    StartDate,
+    EndDate,
+    Name,
+    Hours,
+    Status,
+}
+
+#[derive(Clone, Debug)]
+struct HolidayDisplay {
+    id: i32,
+    date: NaiveDate,
+    name: String,
+    hours: BigDecimal,
+}
+
+#[derive(Clone, Debug)]
+struct PlanDisplay {
+    id: i32,
+    start_date: NaiveDate,
+    end_date: NaiveDate,
+    name: String,
+    description: Option<String>,
+    hours: BigDecimal,
+    status: String,
+}
+
+impl TableViewItem<HolidayColumn> for HolidayDisplay {
+    fn to_column(&self, column: HolidayColumn) -> String {
+        match column {
+            HolidayColumn::Date => self.date.format("%m/%d/%Y").to_string(),
+            HolidayColumn::Name => self.name.clone(),
+            HolidayColumn::Hours => format!("{:.2}", self.hours),
+        }
+    }
+
+    fn cmp(&self, other: &Self, column: HolidayColumn) -> Ordering {
+        match column {
+            HolidayColumn::Date => self.date.cmp(&other.date),
+            HolidayColumn::Name => self.name.cmp(&other.name),
+            HolidayColumn::Hours => self.hours.cmp(&other.hours),
+        }
+    }
+}
+
+impl TableViewItem<PlanColumn> for PlanDisplay {
+    fn to_column(&self, column: PlanColumn) -> String {
+        match column {
+            PlanColumn::StartDate => self.start_date.format("%m/%d/%Y").to_string(),
+            PlanColumn::EndDate => self.end_date.format("%m/%d/%Y").to_string(),
+            PlanColumn::Name => self.name.clone(),
+            PlanColumn::Hours => format!("{:.2}", self.hours),
+            PlanColumn::Status => self.status.clone(),
+        }
+    }
+
+    fn cmp(&self, other: &Self, column: PlanColumn) -> Ordering {
+        match column {
+            PlanColumn::StartDate => self.start_date.cmp(&other.start_date),
+            PlanColumn::EndDate => self.end_date.cmp(&other.end_date),
+            PlanColumn::Name => self.name.cmp(&other.name),
+            PlanColumn::Hours => self.hours.cmp(&other.hours),
+            PlanColumn::Status => self.status.cmp(&other.status),
+        }
+    }
+}
+
+pub fn show_pto_detail(siv: &mut Cursive, pto_id: i32) {
+    use crate::schema::holiday_hours::dsl as holiday_dsl;
+    use crate::schema::pto_plan::dsl as plan_dsl;
+    use crate::schema::ptos::dsl::*;
+
+    let mut conn = establish_connection();
+    
+    let pto = ptos.find(pto_id).first::<models::Pto>(&mut conn).expect("Error loading PTO");
+    
+    let holidays = holiday_dsl::holiday_hours
+        .filter(holiday_dsl::pto_id.eq(pto_id))
+        .order(holiday_dsl::date.asc())
+        .load::<models::HolidayHours>(&mut conn)
+        .expect("Error loading holidays");
+    
+    let plans = plan_dsl::pto_plan
+        .filter(plan_dsl::pto_id.eq(pto_id))
+        .order(plan_dsl::start_date.asc())
+        .load::<models::PtoPlan>(&mut conn)
+        .expect("Error loading PTO plans");
+
+    // Left column: PTO Planning table
+    let mut plan_table = TableView::<PlanDisplay, PlanColumn>::new()
+        .column(PlanColumn::StartDate, "Start", |c| c.width(11))
+        .column(PlanColumn::EndDate, "End", |c| c.width(11))
+        .column(PlanColumn::Name, "Name", |c| c.width(18))
+        .column(PlanColumn::Hours, "Hours", |c| c.width(7))
+        .column(PlanColumn::Status, "Status", |c| c.width(12));
+
+    plan_table.set_items(plans.into_iter().map(|p| PlanDisplay {
+        id: p.id,
+        start_date: p.start_date,
+        end_date: p.end_date,
+        name: p.name.clone(),
+        description: p.description.clone(),
+        hours: p.hours,
+        status: p.status,
+    }).collect::<Vec<_>>());
+
+    plan_table.set_on_select(|siv: &mut Cursive, _row: usize, _index: usize| {
+        let item_count = siv
+            .call_on_name("plan_table", |table: &mut TableView<PlanDisplay, PlanColumn>| {
+                table.len()
+            })
+            .unwrap_or(0);
+        toggle_buttons_visible(siv, item_count, PLAN_TOGGLE_BUTTONS);
+    });
+
+    let plan_buttons = LinearLayout::horizontal()
+        .child(Button::new("Add", move |s| show_add_plan_dialog(s, pto_id, pto.year)))
+        .child(Button::new("Edit", move |s| edit_selected_plan(s, pto_id)).with_name(PLAN_EDIT_BUTTON))
+        .child(Button::new("Delete", |s| delete_selected_plan(s)).with_name(PLAN_DELETE_BUTTON))
+        .child(Button::new("View Description", |s| view_plan_description(s)).with_name(PLAN_VIEW_DESC_BUTTON));
+
+    let left_col = LinearLayout::vertical()
+        .child(Panel::new(plan_table.with_name("plan_table").full_height()))
+        .child(plan_buttons);
+
+    // Right column: Holiday Hours table + Summary
+    let mut holiday_table = TableView::<HolidayDisplay, HolidayColumn>::new()
+        .column(HolidayColumn::Date, "Date", |c| c.width(12))
+        .column(HolidayColumn::Name, "Name", |c| c.width(20))
+        .column(HolidayColumn::Hours, "Hours", |c| c.width(8));
+
+    holiday_table.set_items(holidays.into_iter().map(|h| HolidayDisplay {
+        id: h.id,
+        date: h.date,
+        name: h.name,
+        hours: h.hours,
+    }).collect::<Vec<_>>());
+
+    holiday_table.set_on_select(|siv: &mut Cursive, _row: usize, _index: usize| {
+        let item_count = siv
+            .call_on_name("holiday_table", |table: &mut TableView<HolidayDisplay, HolidayColumn>| {
+                table.len()
+            })
+            .unwrap_or(0);
+        toggle_buttons_visible(siv, item_count, HOLIDAY_TOGGLE_BUTTONS);
+    });
+
+    let holiday_buttons = LinearLayout::horizontal()
+        .child(Button::new("Add", move |s| show_add_holiday_dialog(s, pto_id, pto.year)))
+        .child(Button::new("Edit", move |s| edit_selected_holiday(s, pto_id)).with_name(HOLIDAY_EDIT_BUTTON))
+        .child(Button::new("Delete", |s| delete_selected_holiday(s)).with_name(HOLIDAY_DELETE_BUTTON))
+        .child(Button::new("Copy from Last Year", move |s| copy_holidays_from_last_year(s, pto_id, pto.year)));
+
+    let summary = TextView::new(format!(
+        "Year: {}\nAvailable Hours: {:.2}\nHours Planned: {:.2}\nHours Used: {:.2}\nHours Remaining: {:.2}",
+        pto.year, pto.available_hours, pto.hours_planned, pto.hours_used, pto.hours_remaining
+    ));
+
+    let summary_panel = Panel::new(summary).title("Summary");
+
+    let right_col = LinearLayout::vertical()
+        .child(Panel::new(holiday_table.with_name("holiday_table").full_height()))
+        .child(holiday_buttons)
+        .child(summary_panel);
+
+    let layout = LinearLayout::horizontal()
+        .child(Panel::new(left_col).title("Planned PTO").full_width())
+        .child(Panel::new(right_col).title("Holiday Hours & Summary").full_width());
+
+    siv.add_layer(Dialog::around(layout).title(format!("PTO Detail - {}", pto.year)).full_screen());
+}
+
+fn view_plan_description(siv: &mut Cursive) {
+    let selected = siv
+        .call_on_name("plan_table", |table: &mut TableView<PlanDisplay, PlanColumn>| {
+            table.borrow_item(table.row().unwrap()).cloned()
+        })
+        .flatten();
+
+    if let Some(plan) = selected {
+        let desc_text = plan.description.clone().unwrap_or_else(|| "No description available.".to_string());
+        
+        let dialog = Dialog::around(TextView::new(desc_text))
+            .title(format!("Description: {}", plan.name))
+            .button("Close", |s| {
+                s.pop_layer();
+            });
+        
+        siv.add_layer(dialog);
+    }
+}
+
+fn show_add_holiday_dialog(siv: &mut Cursive, pto_id: i32, pto_year: i32) {
+    let dialog = Dialog::new()
+        .title("Add Holiday")
+        .content(
+            LinearLayout::vertical()
+                .child(TextView::new("Date (MM/DD/YYYY):"))
+                .child(EditView::new().content(get_default_date(pto_year)).with_name("date").fixed_width(15))
+                .child(TextView::new("Name:"))
+                .child(EditView::new().with_name("name").fixed_width(25))
+                .child(TextView::new("Hours:"))
+                .child(EditView::new().content("8").with_name("hours").fixed_width(10))
+        )
+        .button("Ok", move |s| {
+            let date_str = s.call_on_name("date", |v: &mut EditView| v.get_content()).unwrap();
+            let name_str = s.call_on_name("name", |v: &mut EditView| v.get_content()).unwrap();
+            let hours_str = s.call_on_name("hours", |v: &mut EditView| v.get_content()).unwrap();
+
+            let date_val = match parse_date_or_show_error(s, &date_str) {
+                Some(d) => d,
+                None => return,
+            };
+            let hours_val = BigDecimal::parse_bytes(hours_str.as_bytes(), 10).unwrap_or_default();
+
+            let mut conn = establish_connection();
+            let new_holiday = models::NewHolidayHours {
+                pto_id,
+                date: date_val,
+                name: name_str.to_string(),
+                hours: hours_val,
+            };
+
+            diesel::insert_into(schema::holiday_hours::table)
+                .values(&new_holiday)
+                .execute(&mut conn)
+                .expect("Error saving holiday");
+
+            s.pop_layer();
+            s.pop_layer();
+            show_pto_detail(s, pto_id);
+        })
+        .button("Cancel", |s| {
+            s.pop_layer();
+        });
+
+    siv.add_layer(dialog);
+}
+
+fn edit_selected_holiday(siv: &mut Cursive, pto_id: i32) {
+    let selected = siv
+        .call_on_name("holiday_table", |table: &mut TableView<HolidayDisplay, HolidayColumn>| {
+            table.borrow_item(table.row().unwrap()).cloned()
+        })
+        .flatten();
+
+    if let Some(holiday) = selected {
+        let dialog = Dialog::new()
+            .title("Edit Holiday")
+            .content(
+                LinearLayout::vertical()
+                    .child(TextView::new("Date (MM/DD/YYYY):"))
+                    .child(EditView::new().content(holiday.date.format("%m/%d/%Y").to_string()).with_name("date").fixed_width(15))
+                    .child(TextView::new("Name:"))
+                    .child(EditView::new().content(holiday.name.clone()).with_name("name").fixed_width(25))
+                    .child(TextView::new("Hours:"))
+                    .child(EditView::new().content(holiday.hours.to_string()).with_name("hours").fixed_width(10))
+            )
+            .button("Ok", move |s| {
+                let date_str = s.call_on_name("date", |v: &mut EditView| v.get_content()).unwrap();
+                let name_str = s.call_on_name("name", |v: &mut EditView| v.get_content()).unwrap();
+                let hours_str = s.call_on_name("hours", |v: &mut EditView| v.get_content()).unwrap();
+
+                let date_val = match parse_date_or_show_error(s, &date_str) {
+                    Some(d) => d,
+                    None => return,
+                };
+                let hours_val = BigDecimal::parse_bytes(hours_str.as_bytes(), 10).unwrap_or_default();
+
+                let mut conn = establish_connection();
+                diesel::update(schema::holiday_hours::table.find(holiday.id))
+                    .set((
+                        schema::holiday_hours::date.eq(date_val),
+                        schema::holiday_hours::name.eq(name_str.to_string()),
+                        schema::holiday_hours::hours.eq(hours_val),
+                    ))
+                    .execute(&mut conn)
+                    .expect("Error updating holiday");
+
+                s.pop_layer();
+                s.pop_layer();
+                show_pto_detail(s, pto_id);
+            })
+            .button("Cancel", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}
+
+fn delete_selected_holiday(siv: &mut Cursive) {
+    let selected_id = siv
+        .call_on_name("holiday_table", |table: &mut TableView<HolidayDisplay, HolidayColumn>| {
+            table.borrow_item(table.row().unwrap()).map(|item| item.id)
+        })
+        .flatten();
+
+    if let Some(holiday_id) = selected_id {
+        let dialog = Dialog::text("Delete this holiday?")
+            .button("Yes", move |s| {
+                let mut conn = establish_connection();
+                diesel::delete(schema::holiday_hours::table.find(holiday_id))
+                    .execute(&mut conn)
+                    .expect("Error deleting holiday");
+
+                s.pop_layer();
+            })
+            .button("No", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}
+
+fn copy_holidays_from_last_year(siv: &mut Cursive, pto_id: i32, current_year: i32) {
+    let mut conn = establish_connection();
+    
+    // Find PTO record for previous year
+    let prev_year = current_year - 1;
+    let prev_pto = schema::ptos::table
+        .filter(schema::ptos::year.eq(prev_year))
+        .first::<models::Pto>(&mut conn)
+        .optional()
+        .expect("Error loading previous year PTO");
+    
+    if let Some(prev_pto) = prev_pto {
+        // Load holidays from previous year
+        let prev_holidays = schema::holiday_hours::table
+            .filter(schema::holiday_hours::pto_id.eq(prev_pto.id))
+            .load::<models::HolidayHours>(&mut conn)
+            .expect("Error loading previous year holidays");
+        
+        if prev_holidays.is_empty() {
+            siv.add_layer(Dialog::info(format!("No holidays found for year {}", prev_year)));
+            return;
+        }
+        
+        let count = prev_holidays.len();
+        
+        // Copy holidays with updated year
+        for holiday in prev_holidays {
+            let new_date = holiday.date.with_year(current_year)
+                .unwrap_or(holiday.date);
+            
+            let new_holiday = models::NewHolidayHours {
+                pto_id,
+                date: new_date,
+                name: holiday.name.clone(),
+                hours: holiday.hours.clone(),
+            };
+            
+            diesel::insert_into(schema::holiday_hours::table)
+                .values(&new_holiday)
+                .execute(&mut conn)
+                .expect("Error copying holiday");
+        }
+        
+        siv.add_layer(Dialog::info(format!("Copied {} holidays from {}", count, prev_year))
+            .button("Ok", move |s| {
+                s.pop_layer();
+                s.pop_layer();
+                show_pto_detail(s, pto_id);
+            }));
+    } else {
+        siv.add_layer(Dialog::info(format!("No PTO record found for year {}", prev_year)));
+    }
+}
+
+fn show_add_plan_dialog(siv: &mut Cursive, pto_id: i32, pto_year: i32) {
+    let dialog = Dialog::new()
+        .title("Add PTO Plan")
+        .content(
+            LinearLayout::vertical()
+                .child(TextView::new("Start Date (MM/DD/YYYY):"))
+                .child(EditView::new().content(get_default_date(pto_year)).with_name("start_date").fixed_width(15))
+                .child(TextView::new("End Date (MM/DD/YYYY):"))
+                .child(EditView::new().content(get_default_date(pto_year)).with_name("end_date").fixed_width(15))
+                .child(TextView::new("Name:"))
+                .child(EditView::new().with_name("name").fixed_width(25))
+                .child(TextView::new("Description:"))
+                .child(EditView::new().with_name("description").fixed_width(40))
+                .child(TextView::new("Hours (leave blank for auto calculation):"))
+                .child(EditView::new().with_name("hours").fixed_width(10))
+        )
+        .button("Ok", move |s| {
+            let start_str = s.call_on_name("start_date", |v: &mut EditView| v.get_content()).unwrap();
+            let end_str = s.call_on_name("end_date", |v: &mut EditView| v.get_content()).unwrap();
+            let name_str = s.call_on_name("name", |v: &mut EditView| v.get_content()).unwrap();
+            let desc_str = s.call_on_name("description", |v: &mut EditView| v.get_content()).unwrap();
+            let hours_str = s.call_on_name("hours", |v: &mut EditView| v.get_content()).unwrap();
+
+            let start_val = match parse_date_or_show_error(s, &start_str) {
+                Some(d) => d,
+                None => return,
+            };
+            let end_val = match parse_date_or_show_error(s, &end_str) {
+                Some(d) => d,
+                None => return,
+            };
+            
+            let (hours_val, custom_hours_val) = calculate_or_custom_hours(&hours_str, start_val, end_val, pto_id);
+
+            let mut conn = establish_connection();
+            let new_plan = models::NewPtoPlan {
+                pto_id,
+                start_date: start_val,
+                end_date: end_val,
+                name: name_str.to_string(),
+                description: if desc_str.is_empty() { None } else { Some(desc_str.to_string()) },
+                hours: hours_val,
+                status: "Planned".to_string(),
+                custom_hours: custom_hours_val,
+            };
+
+            diesel::insert_into(schema::pto_plan::table)
+                .values(&new_plan)
+                .execute(&mut conn)
+                .expect("Error saving PTO plan");
+
+            s.pop_layer();
+            s.pop_layer();
+            show_pto_detail(s, pto_id);
+        })
+        .button("Cancel", |s| {
+            s.pop_layer();
+        });
+
+    siv.add_layer(dialog);
+}
+
+fn edit_selected_plan(siv: &mut Cursive, pto_id: i32) {
+    let selected = siv
+        .call_on_name("plan_table", |table: &mut TableView<PlanDisplay, PlanColumn>| {
+            table.borrow_item(table.row().unwrap()).cloned()
+        })
+        .flatten();
+
+    if let Some(plan) = selected {
+        let dialog = Dialog::new()
+            .title("Edit PTO Plan")
+            .content(
+                LinearLayout::vertical()
+                    .child(TextView::new("Start Date (MM/DD/YYYY):"))
+                    .child(EditView::new().content(plan.start_date.format("%m/%d/%Y").to_string()).with_name("start_date").fixed_width(15))
+                    .child(TextView::new("End Date (MM/DD/YYYY):"))
+                    .child(EditView::new().content(plan.end_date.format("%m/%d/%Y").to_string()).with_name("end_date").fixed_width(15))
+                    .child(TextView::new("Name:"))
+                    .child(EditView::new().content(plan.name.clone()).with_name("name").fixed_width(25))
+                    .child(TextView::new("Description:"))
+                    .child(EditView::new().content(plan.description.clone().unwrap_or_default()).with_name("description").fixed_width(40))
+                    .child(TextView::new("Hours (leave blank for auto calculation):"))
+                    .child(EditView::new().content(plan.hours.to_string()).with_name("hours").fixed_width(10))
+                    .child(TextView::new("Status:"))
+                    .child({
+                        let mut select = SelectView::new();
+                        let current_status = models::PtoStatus::from(plan.status.clone());
+                        
+                        for status in models::PtoStatus::all() {
+                            select.add_item(status.to_string(), status);
+                        }
+                        
+                        select.set_selection(current_status as usize);
+                        select.with_name("status")
+                    })
+            )
+            .button("Ok", move |s| {
+                let start_str = s.call_on_name("start_date", |v: &mut EditView| v.get_content()).unwrap();
+                let end_str = s.call_on_name("end_date", |v: &mut EditView| v.get_content()).unwrap();
+                let name_str = s.call_on_name("name", |v: &mut EditView| v.get_content()).unwrap();
+                let desc_str = s.call_on_name("description", |v: &mut EditView| v.get_content()).unwrap();
+                let hours_str = s.call_on_name("hours", |v: &mut EditView| v.get_content()).unwrap();
+                let status = s.call_on_name("status", |v: &mut SelectView<models::PtoStatus>| {
+                    v.selection().map(|s| *s.as_ref())
+                }).unwrap().unwrap_or(models::PtoStatus::Planned);
+
+                let start_val = match parse_date_or_show_error(s, &start_str) {
+                    Some(d) => d,
+                    None => return,
+                };
+                let end_val = match parse_date_or_show_error(s, &end_str) {
+                    Some(d) => d,
+                    None => return,
+                };
+                
+                let (hours_val, custom_hours_val) = calculate_or_custom_hours(&hours_str, start_val, end_val, pto_id);
+
+                let mut conn = establish_connection();
+                diesel::update(schema::pto_plan::table.find(plan.id))
+                    .set((
+                        schema::pto_plan::start_date.eq(start_val),
+                        schema::pto_plan::end_date.eq(end_val),
+                        schema::pto_plan::name.eq(name_str.to_string()),
+                        schema::pto_plan::description.eq(if desc_str.is_empty() { None } else { Some(desc_str.to_string()) }),
+                        schema::pto_plan::hours.eq(hours_val),
+                        schema::pto_plan::status.eq(String::from(status)),
+                        schema::pto_plan::custom_hours.eq(custom_hours_val),
+                    ))
+                    .execute(&mut conn)
+                    .expect("Error updating PTO plan");
+
+                s.pop_layer();
+                s.pop_layer();
+                show_pto_detail(s, pto_id);
+            })
+            .button("Cancel", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}
+
+fn delete_selected_plan(siv: &mut Cursive) {
+    let selected_id = siv
+        .call_on_name("plan_table", |table: &mut TableView<PlanDisplay, PlanColumn>| {
+            table.borrow_item(table.row().unwrap()).map(|item| item.id)
+        })
+        .flatten();
+
+    if let Some(plan_id) = selected_id {
+        let dialog = Dialog::text("Delete this PTO plan?")
+            .button("Yes", move |s| {
+                let mut conn = establish_connection();
+                diesel::delete(schema::pto_plan::table.find(plan_id))
+                    .execute(&mut conn)
+                    .expect("Error deleting PTO plan");
+
+                s.pop_layer();
+            })
+            .button("No", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}

--- a/src/pto_logic.rs
+++ b/src/pto_logic.rs
@@ -1,0 +1,98 @@
+use chrono::{Datelike, NaiveDate, Weekday};
+use bigdecimal::BigDecimal;
+
+/// Calculate workday hours between start and end dates (inclusive)
+/// Counts M-F as 8-hour workdays, subtracts holiday hours in range
+pub fn calculate_pto_hours(
+    start_date: NaiveDate,
+    end_date: NaiveDate,
+    holidays: &[(NaiveDate, BigDecimal)],
+) -> BigDecimal {
+    let mut workdays = 0;
+    let mut current = start_date;
+
+    loop {
+        match current.weekday() {
+            Weekday::Mon | Weekday::Tue | Weekday::Wed | Weekday::Thu | Weekday::Fri => {
+                workdays += 1;
+            }
+            _ => {}
+        }
+        
+        if current == end_date {
+            break;
+        }
+        
+        current = current.succ_opt().unwrap_or(current);
+    }
+
+    let base_hours = BigDecimal::from(workdays * 8);
+    
+    let holiday_hours: BigDecimal = holidays
+        .iter()
+        .filter(|(date, _)| *date >= start_date && *date <= end_date)
+        .map(|(_, hours)| hours.clone())
+        .sum();
+
+    base_hours - holiday_hours
+}
+
+/// Calculate hours per day for validation (warn if > 8)
+pub fn calculate_hours_per_day(hours: &BigDecimal, start_date: NaiveDate, end_date: NaiveDate) -> BigDecimal {
+    let days = (end_date - start_date).num_days() + 1;
+    if days == 0 {
+        return BigDecimal::from(0);
+    }
+    hours / BigDecimal::from(days)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bigdecimal::BigDecimal;
+
+    #[test]
+    fn test_workday_calculation_simple() {
+        // Mon Jan 1 to Fri Jan 5, 2024 = 5 workdays = 40 hours
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2024, 1, 5).unwrap();
+        let holidays = vec![];
+        
+        let result = calculate_pto_hours(start, end, &holidays);
+        assert_eq!(result, BigDecimal::from(40));
+    }
+
+    #[test]
+    fn test_workday_calculation_with_weekend() {
+        // Mon Jan 1 to Sun Jan 7, 2024 = 5 workdays = 40 hours
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2024, 1, 7).unwrap();
+        let holidays = vec![];
+        
+        let result = calculate_pto_hours(start, end, &holidays);
+        assert_eq!(result, BigDecimal::from(40));
+    }
+
+    #[test]
+    fn test_workday_calculation_with_holiday() {
+        // Mon Jan 1 to Fri Jan 5, with 8-hour holiday on Jan 3
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2024, 1, 5).unwrap();
+        let holidays = vec![
+            (NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(), BigDecimal::from(8))
+        ];
+        
+        let result = calculate_pto_hours(start, end, &holidays);
+        assert_eq!(result, BigDecimal::from(32)); // 40 - 8
+    }
+
+    #[test]
+    fn test_hours_per_day() {
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2024, 1, 5).unwrap();
+        let hours = BigDecimal::from(40);
+        
+        let result = calculate_hours_per_day(&hours, start, end);
+        assert_eq!(result, BigDecimal::from(8));
+    }
+}

--- a/src/pto_table.rs
+++ b/src/pto_table.rs
@@ -1,0 +1,235 @@
+use std::cmp::Ordering;
+use bigdecimal::BigDecimal;
+use cursive::Cursive;
+use cursive::traits::*;
+use cursive::views::{Button, Dialog, EditView, LinearLayout, Panel};
+use cursive_table_view::{TableView, TableViewItem};
+use diesel::prelude::*;
+
+use crate::models;
+use crate::schema::ptos::dsl::*;
+use crate::db::establish_connection;
+use crate::ui_helpers::toggle_buttons_visible;
+
+const PTO_VIEW_BUTTON: &str = "pto_table_view_button";
+const PTO_EDIT_BUTTON: &str = "pto_table_edit_button";
+const PTO_DELETE_BUTTON: &str = "pto_table_delete_button";
+const TOGGLE_BUTTONS: &[&str] = &[PTO_VIEW_BUTTON, PTO_EDIT_BUTTON, PTO_DELETE_BUTTON];
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+enum PtoColumn {
+    Year,
+    AvailableHours,
+    HoursPlanned,
+    HoursUsed,
+    HoursRemaining,
+}
+
+#[derive(Clone, Debug)]
+struct PtoDisplay {
+    id: i32,
+    year: i32,
+    available_hours: BigDecimal,
+    hours_planned: BigDecimal,
+    hours_used: BigDecimal,
+    hours_remaining: BigDecimal,
+}
+
+impl From<models::Pto> for PtoDisplay {
+    fn from(pto: models::Pto) -> Self {
+        PtoDisplay {
+            id: pto.id,
+            year: pto.year,
+            available_hours: pto.available_hours,
+            hours_planned: pto.hours_planned,
+            hours_used: pto.hours_used,
+            hours_remaining: pto.hours_remaining,
+        }
+    }
+}
+
+impl TableViewItem<PtoColumn> for PtoDisplay {
+    fn to_column(&self, column: PtoColumn) -> String {
+        match column {
+            PtoColumn::Year => self.year.to_string(),
+            PtoColumn::AvailableHours => format!("{:.2}", self.available_hours),
+            PtoColumn::HoursPlanned => format!("{:.2}", self.hours_planned),
+            PtoColumn::HoursUsed => format!("{:.2}", self.hours_used),
+            PtoColumn::HoursRemaining => format!("{:.2}", self.hours_remaining),
+        }
+    }
+
+    fn cmp(&self, other: &Self, column: PtoColumn) -> Ordering where Self: Sized {
+        match column {
+            PtoColumn::Year => self.year.cmp(&other.year),
+            PtoColumn::AvailableHours => self.available_hours.cmp(&other.available_hours),
+            PtoColumn::HoursPlanned => self.hours_planned.cmp(&other.hours_planned),
+            PtoColumn::HoursUsed => self.hours_used.cmp(&other.hours_used),
+            PtoColumn::HoursRemaining => self.hours_remaining.cmp(&other.hours_remaining),
+        }
+    }
+}
+
+pub fn show_pto_table_view(siv: &mut Cursive) {
+    let mut conn = establish_connection();
+    
+    let pto_records = ptos
+        .order(year.desc())
+        .load::<models::Pto>(&mut conn)
+        .expect("Error loading PTOs");
+
+    let mut table = TableView::<PtoDisplay, PtoColumn>::new()
+        .column(PtoColumn::Year, "Year", |c| c.width(10))
+        .column(PtoColumn::AvailableHours, "Available", |c| c.width(12))
+        .column(PtoColumn::HoursPlanned, "Planned", |c| c.width(12))
+        .column(PtoColumn::HoursUsed, "Used", |c| c.width(12))
+        .column(PtoColumn::HoursRemaining, "Remaining", |c| c.width(12));
+
+    table.set_items(pto_records.into_iter().map(PtoDisplay::from).collect::<Vec<_>>());
+
+    table.set_on_select(|siv: &mut Cursive, _row: usize, _index: usize| {
+        let item_count = siv
+            .call_on_name("pto_table", |table: &mut TableView<PtoDisplay, PtoColumn>| {
+                table.len()
+            })
+            .unwrap_or(0);
+        toggle_buttons_visible(siv, item_count, TOGGLE_BUTTONS);
+    });
+
+    let table_view = Panel::new(table.with_name("pto_table").full_screen())
+        .title("PTO Records");
+
+    let buttons = LinearLayout::horizontal()
+        .child(Button::new("Add", |s| show_add_pto_dialog(s)))
+        .child(Button::new("View", |s| view_selected_pto(s)).with_name(PTO_VIEW_BUTTON))
+        .child(Button::new("Edit", |s| edit_selected_pto(s)).with_name(PTO_EDIT_BUTTON))
+        .child(Button::new("Delete", |s| delete_selected_pto(s)).with_name(PTO_DELETE_BUTTON));
+
+    let layout = LinearLayout::vertical()
+        .child(table_view)
+        .child(buttons);
+
+    siv.add_layer(layout);
+}
+
+fn show_add_pto_dialog(siv: &mut Cursive) {
+    let dialog = Dialog::new()
+        .title("Add PTO Record")
+        .content(
+            LinearLayout::vertical()
+                .child(
+                    LinearLayout::horizontal()
+                        .child(Panel::new(EditView::new().with_name("year").fixed_width(10)))
+                        .child(Panel::new(EditView::new().with_name("available_hours").fixed_width(10)))
+                )
+        )
+        .button("Ok", |s| {
+            let year_str = s.call_on_name("year", |v: &mut EditView| v.get_content()).unwrap();
+            let available_str = s.call_on_name("available_hours", |v: &mut EditView| v.get_content()).unwrap();
+
+            let year_val: i32 = year_str.parse().unwrap_or(0);
+            let available_val = BigDecimal::parse_bytes(available_str.as_bytes(), 10).unwrap_or_default();
+
+            let mut conn = establish_connection();
+            let new_pto = models::NewPto {
+                year: year_val,
+                available_hours: available_val,
+            };
+
+            diesel::insert_into(ptos)
+                .values(&new_pto)
+                .execute(&mut conn)
+                .expect("Error saving PTO");
+
+            s.pop_layer();
+            s.pop_layer();
+            show_pto_table_view(s);
+        })
+        .button("Cancel", |s| {
+            s.pop_layer();
+        });
+
+    siv.add_layer(dialog);
+}
+
+fn view_selected_pto(siv: &mut Cursive) {
+    let selected_id = siv
+        .call_on_name("pto_table", |table: &mut TableView<PtoDisplay, PtoColumn>| {
+            table.borrow_item(table.row().unwrap()).map(|item| item.id)
+        })
+        .flatten();
+
+    if let Some(pto_id) = selected_id {
+        siv.pop_layer();
+        crate::pto_detail::show_pto_detail(siv, pto_id);
+    }
+}
+
+fn edit_selected_pto(siv: &mut Cursive) {
+    let selected_id = siv
+        .call_on_name("pto_table", |table: &mut TableView<PtoDisplay, PtoColumn>| {
+            table.borrow_item(table.row().unwrap()).map(|item| item.id)
+        })
+        .flatten();
+
+    if let Some(pto_id) = selected_id {
+        let mut conn = establish_connection();
+        let pto_record = ptos.find(pto_id).first::<models::Pto>(&mut conn).expect("Error loading PTO");
+
+        let dialog = Dialog::new()
+            .title("Edit PTO Record")
+            .content(
+                LinearLayout::vertical()
+                    .child(
+                        LinearLayout::horizontal()
+                            .child(Panel::new(EditView::new().content(pto_record.available_hours.to_string()).with_name("available_hours").fixed_width(10)))
+                    )
+            )
+            .button("Ok", move |s| {
+                let available_str = s.call_on_name("available_hours", |v: &mut EditView| v.get_content()).unwrap();
+                let available_val = BigDecimal::parse_bytes(available_str.as_bytes(), 10).unwrap_or_default();
+
+                let mut conn = establish_connection();
+                diesel::update(ptos.find(pto_id))
+                    .set(available_hours.eq(available_val))
+                    .execute(&mut conn)
+                    .expect("Error updating PTO");
+
+                s.pop_layer();
+                s.pop_layer();
+                show_pto_table_view(s);
+            })
+            .button("Cancel", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}
+
+fn delete_selected_pto(siv: &mut Cursive) {
+    let selected_id = siv
+        .call_on_name("pto_table", |table: &mut TableView<PtoDisplay, PtoColumn>| {
+            table.borrow_item(table.row().unwrap()).map(|item| item.id)
+        })
+        .flatten();
+
+    if let Some(pto_id) = selected_id {
+        let dialog = Dialog::text("Delete this PTO record?")
+            .button("Yes", move |s| {
+                let mut conn = establish_connection();
+                diesel::delete(ptos.find(pto_id))
+                    .execute(&mut conn)
+                    .expect("Error deleting PTO");
+
+                s.pop_layer();
+                s.pop_layer();
+                show_pto_table_view(s);
+            })
+            .button("No", |s| {
+                s.pop_layer();
+            });
+
+        siv.add_layer(dialog);
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,6 +12,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    holiday_hours (id) {
+        id -> Int4,
+        pto_id -> Int4,
+        date -> Date,
+        name -> Varchar,
+        hours -> Numeric,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     incomes (id) {
         id -> Int4,
         date -> Date,
@@ -48,8 +59,47 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    pto_plan (id) {
+        id -> Int4,
+        pto_id -> Int4,
+        start_date -> Date,
+        end_date -> Date,
+        name -> Varchar,
+        description -> Nullable<Text>,
+        hours -> Numeric,
+        status -> Varchar,
+        custom_hours -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    ptos (id) {
+        id -> Int4,
+        year -> Int4,
+        prev_year_hours -> Numeric,
+        available_hours -> Numeric,
+        hours_planned -> Numeric,
+        hours_used -> Numeric,
+        hours_remaining -> Numeric,
+        rollover_hours -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::joinable!(holiday_hours -> ptos (pto_id));
 diesel::joinable!(incomes -> ledgers (ledger_id));
 diesel::joinable!(ledger_bills -> bills (bill_id));
 diesel::joinable!(ledger_bills -> ledgers (ledger_id));
+diesel::joinable!(pto_plan -> ptos (pto_id));
 
-diesel::allow_tables_to_appear_in_same_query!(bills, incomes, ledger_bills, ledgers,);
+diesel::allow_tables_to_appear_in_same_query!(
+    bills,
+    holiday_hours,
+    incomes,
+    ledger_bills,
+    ledgers,
+    pto_plan,
+    ptos,
+);


### PR DESCRIPTION
## PTO Tracking Feature (v0.6.0)

Closes #13

### New Features
- **3 database tables:** ptos, pto_plan, holiday_hours
- **Auto-calculate workday hours:** Leave blank = M-F 8hr/day minus holidays
- **Database triggers:** Auto-update planned/used/remaining hours
- **Status management:** Planned/Requested/Approved/Completed (enum-based dropdown)
- **Copy holidays:** Duplicate from previous year with updated dates

### UI
- Press `p` to open PTO view
- **PTOs table view:** Add | View | Edit | Delete
- **PTO detail screen:** 2-column layout
  - Left: Planned PTO table with status
  - Right: Holiday Hours + Summary
- **Defaults:** Dates = 01/01/YEAR, Holiday hours = 8

### Technical
- Business logic with tests in `pto_logic.rs`
- PostgreSQL triggers for aggregation
- PtoStatus enum for type safety
- Helper functions for date validation and defaults

### Testing
- Manual testing complete
- Unit tests for workday calculation
- Database migration tested