### PR TITLE
Add footer to PTOs table view

### DIFF
--- a/src/pto_table.rs
+++ b/src/pto_table.rs
@@ -109,7 +109,13 @@ pub fn show_pto_table_view(siv: &mut Cursive) {
         .child(table_view)
         .child(buttons);
 
-    siv.add_layer(layout);
+    let screen = crate::common_layout::create_screen(
+        "PTO Records",
+        layout,
+        &crate::common_layout::view_footer()
+    );
+
+    siv.add_layer(screen);
 }
 
 fn show_add_pto_dialog(siv: &mut Cursive) {


### PR DESCRIPTION
## Description
Adds the missing footer to the PTOs table view (press `p`).

## Changes
- Use `common_layout::create_screen()` instead of direct `add_layer()`
- Adds standard footer: `q:Quit | h:Home | i:Income | b:Bills | l:Ledger | p:PTO`
- Matches pattern in other table views (income, bills, ledger)

## Note
The PTO detail screen footer was already fixed in #20. This PR completes the footer addition to all PTO screens.