### PR TITLE
Add Terraform infrastructure for Azure PostgreSQL

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,2 +1,0 @@
-# Development environment - used by diesel CLI
-DATABASE_URL=postgres://mrcunninghamz@localhost/money_bae_dev

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,3 @@
+# Development environment - used by diesel CLI
+# Copy this file to .env.dev and update with your actual database URL
+DATABASE_URL=postgres://username:password@hostname/database_name

--- a/.env.prod
+++ b/.env.prod
@@ -1,2 +1,0 @@
-# Production environment - used by diesel CLI
-DATABASE_URL=postgres://mrcunninghamz@localhost/money_bae

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,3 @@
+# Production environment - used by diesel CLI
+# Copy this file to .env.prod and update with your actual database URL
+DATABASE_URL=postgres://username:password@hostname/database_name

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 
 # Environment variables
 .env
-!.env.dev
-!.env.prod
+.env.dev
+.env.prod
 
 # IDE files
 .idea/
@@ -30,3 +30,12 @@ Cargo.lock.bak
 *.dump
 *.sql.gz
 *.backup
+
+# Terraform
+**/.terraform/
+**/.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars.backup
+*.tfplan
+.terraform.tfstate.lock.info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,26 @@ Determined by `cfg!(debug_assertions)` in `configuration_manager.rs`.
 
 ### Database Setup
 
-**Create databases:**
+**Create environment files from examples:**
 ```bash
+cp .env.dev.example .env.dev
+cp .env.prod.example .env.prod
+```
+
+**Edit with your database URLs:**
+```bash
+# For local databases:
 createdb money_bae_dev
 createdb money_bae
+
+# .env.dev
+DATABASE_URL=postgres://username@localhost/money_bae_dev
+
+# .env.prod
+DATABASE_URL=postgres://username@localhost/money_bae
+
+# For Azure PostgreSQL (from Terraform outputs):
+# DATABASE_URL=postgres://username:password@psql-mb-core-cus-dev.postgres.database.azure.com/money_bae?sslmode=require
 ```
 
 **Configure via confy files:**
@@ -51,9 +67,13 @@ diesel migration run
 ```
 
 **Files:**
-- `.env.dev` - Dev database URL (tracked in git)
-- `.env.prod` - Prod database URL (tracked in git)
+- `.env.dev.example` - Template for dev database (tracked in git)
+- `.env.prod.example` - Template for prod database (tracked in git)
+- `.env.dev` - Actual dev database URL (gitignored, contains credentials)
+- `.env.prod` - Actual prod database URL (gitignored, contains credentials)
 - `.env` - Active env (gitignored, created by helper scripts)
+
+**⚠️ NEVER commit `.env`, `.env.dev`, or `.env.prod` - they contain database credentials**
 
 ## Build & Run Commands
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,25 @@ git clone git@github.com:mrcunninghamz/money-bae.git
 cd money-bae
 ```
 
-2. Set up databases:
+2. Set up environment files:
 ```bash
-# Create development and production databases
+# Copy example files to create your environment files
+cp .env.dev.example .env.dev
+cp .env.prod.example .env.prod
+
+# Edit with your database URLs
+vi .env.dev
+vi .env.prod
+```
+
+3. Set up databases:
+```bash
+# For local databases:
 createdb money_bae_dev
 createdb money_bae
+
+# For Azure PostgreSQL, use connection strings from Terraform outputs
+# Example: postgres://username:password@psql-mb-core-cus-dev.postgres.database.azure.com/money_bae?sslmode=require
 
 # Switch to development environment
 ./use-dev-env.sh
@@ -55,16 +69,17 @@ createdb money_bae
 diesel migration run
 ```
 
-3. Configure application:
+4. Configure application:
 ```bash
 # Edit development config (auto-created on first run)
 vi ~/.config/money-bae-dev/money-bae-dev.toml
 
 # Add your database connection string:
-# database_connection_string = "postgres://username@localhost/money_bae_dev"
+# For local: database_connection_string = "postgres://username@localhost/money_bae_dev"
+# For Azure: database_connection_string = "postgres://username:password@psql-mb-core-cus-dev.postgres.database.azure.com/money_bae?sslmode=require"
 ```
 
-4. Build and run:
+5. Build and run:
 ```bash
 cargo run
 ```
@@ -159,9 +174,25 @@ database_connection_string = "postgres://username@localhost/database_name"
 
 ### Database Environment Files
 
-Diesel CLI uses `.env` files for migrations:
-- `.env.dev` - Development database
-- `.env.prod` - Production database
+Diesel CLI uses `.env` files for migrations. **Never commit these files - they contain credentials.**
+
+**Setup:**
+```bash
+# Copy example files
+cp .env.dev.example .env.dev
+cp .env.prod.example .env.prod
+
+# Edit with your database URLs
+vi .env.dev   # Development database URL
+vi .env.prod  # Production database URL
+```
+
+**Files:**
+- `.env.dev.example` - Template for dev database (tracked in git)
+- `.env.prod.example` - Template for prod database (tracked in git)
+- `.env.dev` - Actual dev database URL (gitignored, contains credentials)
+- `.env.prod` - Actual prod database URL (gitignored, contains credentials)
+- `.env` - Active env (gitignored, created by helper scripts)
 
 **Helper scripts:**
 ```bash

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,72 @@
+# Money-Bae - Terraform Infrastructure
+
+Terraform configuration for deploying Money-Bae core infrastructure on Azure.
+
+## Architecture
+
+- **Resource Group**: `rg-mb-core-cus-dev`
+- **PostgreSQL Database**: (future) Flexible Server for TUI application data
+
+## Prerequisites
+
+- Azure CLI authenticated (`az login`)
+- Terraform >= 1.0
+- Azure subscription with permissions to create resources
+- Remote state storage account (created separately)
+
+## Local Deployment
+
+### 1. Initialize Backend
+
+Configure remote state storage:
+
+```bash
+cd infrastructure
+
+terraform init \
+  -backend-config="resource_group_name=rg-moneybae-tfstate-shared" \
+  -backend-config="storage_account_name=stmbtfstateshared" \
+  -backend-config="container_name=tfstate" \
+  -backend-config="key=core/dev.cus.tfstate"
+```
+
+### 2. Plan
+
+```bash
+terraform plan -var-file="environments/dev.cus.tfvars"
+```
+
+### 3. Apply
+
+```bash
+terraform apply -var-file="environments/dev.cus.tfvars"
+```
+
+## CI/CD Pipeline
+
+Infrastructure deployment will be handled by Azure DevOps pipeline (future).
+
+## Outputs
+
+- `resource_group_name`: Resource group name
+- `resource_group_location`: Resource group location
+
+## Module Structure
+
+```
+infrastructure/
+├── main.tf              # Main orchestration
+├── providers.tf         # Azure provider config
+├── variables.tf         # Input variables
+├── outputs.tf           # Output values
+├── environments/        # Environment-specific tfvars
+│   └── dev.cus.tfvars
+└── modules/             # Reusable modules (future)
+    └── postgresql/      # PostgreSQL Flexible Server module
+```
+
+## Destroy
+
+```bash
+terraform destroy -var-file="environments/dev.cus.tfvars"
+```

--- a/infrastructure/environments/dev.cus.tfvars
+++ b/infrastructure/environments/dev.cus.tfvars
@@ -1,0 +1,14 @@
+environment             = "dev"
+location                = "centralus"
+location_abrv           = "cus"
+app_short_name          = "mb"
+component               = "core"
+db_allow_public_access  = true
+db_admin_login          = "mbae"
+
+tags = {
+  Environment = "dev"
+  Application = "MoneyBae"
+  Component   = "Core"
+  ManagedBy   = "Terraform"
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "main" {
+  name     = "rg-${var.app_short_name}-${var.component}-${var.location_abrv}-${var.environment}"
+  location = var.location
+  tags     = var.tags
+}
+
+module "postgresql" {
+  source = "./modules/postgresql"
+
+  server_name            = "psql-${var.app_short_name}-${var.component}-${var.location_abrv}-${var.environment}"
+  resource_group_name    = azurerm_resource_group.main.name
+  location               = azurerm_resource_group.main.location
+  database_name          = "money_bae"
+  administrator_login    = var.db_admin_login
+  administrator_password = var.db_admin_password
+  allow_public_access    = var.db_allow_public_access
+  tags                   = var.tags
+}

--- a/infrastructure/modules/postgresql/main.tf
+++ b/infrastructure/modules/postgresql/main.tf
@@ -1,0 +1,39 @@
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = var.server_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  administrator_login    = var.administrator_login
+  administrator_password = var.administrator_password
+
+  sku_name   = "B_Standard_B1ms"
+  storage_mb = 32768
+  version    = "16"
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+
+  tags = var.tags
+}
+
+resource "azurerm_postgresql_flexible_server_database" "main" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_services" {
+  name             = "AllowAzureServices"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_all" {
+  count            = var.allow_public_access ? 1 : 0
+  name             = "AllowAll"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "255.255.255.255"
+}

--- a/infrastructure/modules/postgresql/outputs.tf
+++ b/infrastructure/modules/postgresql/outputs.tf
@@ -1,0 +1,25 @@
+output "server_id" {
+  value       = azurerm_postgresql_flexible_server.main.id
+  description = "ID of the PostgreSQL Flexible Server"
+}
+
+output "server_name" {
+  value       = azurerm_postgresql_flexible_server.main.name
+  description = "Name of the PostgreSQL Flexible Server"
+}
+
+output "server_fqdn" {
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+  description = "Fully qualified domain name of the PostgreSQL server"
+}
+
+output "database_name" {
+  value       = azurerm_postgresql_flexible_server_database.main.name
+  description = "Name of the PostgreSQL database"
+}
+
+output "connection_string" {
+  value       = "postgresql://${var.administrator_login}@${azurerm_postgresql_flexible_server.main.name}:${var.administrator_password}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/${azurerm_postgresql_flexible_server_database.main.name}?sslmode=require"
+  description = "PostgreSQL connection string"
+  sensitive   = true
+}

--- a/infrastructure/modules/postgresql/variables.tf
+++ b/infrastructure/modules/postgresql/variables.tf
@@ -1,0 +1,44 @@
+variable "server_name" {
+  type        = string
+  description = "Name of the PostgreSQL Flexible Server"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the server"
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the database to create"
+  default     = "money_bae"
+}
+
+variable "administrator_login" {
+  type        = string
+  description = "Administrator login for PostgreSQL server"
+  sensitive   = true
+}
+
+variable "administrator_password" {
+  type        = string
+  description = "Administrator password for PostgreSQL server"
+  sensitive   = true
+}
+
+variable "allow_public_access" {
+  type        = bool
+  description = "Allow public access to the database (dev only)"
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all resources"
+  default     = {}
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,30 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.main.name
+  description = "Name of the resource group"
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.main.location
+  description = "Location of the resource group"
+}
+
+output "postgresql_server_name" {
+  value       = module.postgresql.server_name
+  description = "Name of the PostgreSQL server"
+}
+
+output "postgresql_server_fqdn" {
+  value       = module.postgresql.server_fqdn
+  description = "FQDN of the PostgreSQL server"
+}
+
+output "postgresql_database_name" {
+  value       = module.postgresql.database_name
+  description = "Name of the PostgreSQL database"
+}
+
+output "postgresql_connection_string" {
+  value       = module.postgresql.connection_string
+  description = "PostgreSQL connection string"
+  sensitive   = true
+}

--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=4.1.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  subscription_id = "c6f1212c-ec19-425f-96a0-41f2db717ea8"
+  features {}
+  resource_provider_registrations = "none"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,50 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (dev, test, prod)"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for resources"
+}
+
+variable "location_abrv" {
+  type        = string
+  description = "Abbreviated location name (eus, cus, wus)"
+}
+
+variable "app_short_name" {
+  type        = string
+  description = "Application short name"
+  default     = "mb"
+}
+
+variable "component" {
+  type        = string
+  description = "Component name"
+  default     = "core"
+}
+
+variable "db_admin_login" {
+  type        = string
+  description = "PostgreSQL administrator login"
+  sensitive   = true
+}
+
+variable "db_admin_password" {
+  type        = string
+  description = "PostgreSQL administrator password"
+  sensitive   = true
+}
+
+variable "db_allow_public_access" {
+  type        = bool
+  description = "Allow public access to PostgreSQL (dev only)"
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all resources"
+  default     = {}
+}


### PR DESCRIPTION
- Add infrastructure/ with Terraform config for Azure resources
- Create PostgreSQL module (B1ms, 32GB, PostgreSQL 16)
- Add environment-specific tfvars (dev.cus)
- Update .gitignore: stop tracking .env files, add Terraform patterns
- Add .env.dev.example and .env.prod.example templates
- Update README.md and CLAUDE.md with Azure DB setup instructions
- Document credential management and security best practices