### PR TITLE
Add currency formatting and input parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "money-bae"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -536,6 +542,7 @@ dependencies = [
  "diesel",
  "dotenvy",
  "log",
+ "rusty-money",
  "serde",
  "simplelog",
 ]
@@ -721,10 +728,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-money"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ac0a3274868e5d2615e749ad3b944d93cf846deefd46ea918a225e5d53856d"
+dependencies = [
+ "rust_decimal",
+]
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4"
 simplelog = "0.12"
 confy = "2.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
+rusty-money = "0.5.0"

--- a/src/bill_table.rs
+++ b/src/bill_table.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::rc::Rc;
-use std::str::FromStr;
 use bigdecimal::BigDecimal;
 use chrono::{Datelike, Local, NaiveDate};
 use cursive::Cursive;
@@ -9,7 +8,7 @@ use cursive::views::{Button, Checkbox, Dialog, EditView, HideableView, LinearLay
 use cursive_table_view::{TableView, TableViewItem};
 use crate::models;
 use crate::repositories::bill_repo::BillRepo;
-use crate::ui_helpers::toggle_buttons_visible;
+use crate::ui_helpers::{format_currency, parse_currency, toggle_buttons_visible};
 
 // Button name constants
 const BILL_EDIT_BUTTON: &str = "bill_table_edit_button";
@@ -51,7 +50,7 @@ impl TableViewItem<BasicColumn> for BillDisplay {
     fn to_column(&self, column: BasicColumn) -> String {
         match column {
             BasicColumn::Name => self.name.to_string(),
-            BasicColumn::Amount => self.amount.to_string(),
+            BasicColumn::Amount => format_currency(&self.amount),
             BasicColumn::DueDay => self.due_day.map_or("-".to_string(), |d| d.to_string()),
             BasicColumn::IsAutoPay => self.is_auto_pay.to_string()
         }
@@ -148,7 +147,7 @@ fn bill_form(siv: &mut Cursive, existing: Option<BillDisplay>, bill_repo: &Rc<Bi
 
     let amount_value = existing
         .as_ref()
-        .map(|b| b.amount.to_string())
+        .map(|b| format_currency(&b.amount))
         .unwrap_or_default();
 
     let due_day_value = existing
@@ -200,7 +199,7 @@ fn bill_form(siv: &mut Cursive, existing: Option<BillDisplay>, bill_repo: &Rc<Bi
                 }
 
                 // Validate amount
-                let amount_bd = BigDecimal::from_str(&amount_str);
+                let amount_bd = parse_currency(&amount_str);
                 if amount_bd.is_err() {
                     s.add_layer(Dialog::info("Invalid amount format"));
                     return;

--- a/src/income_table.rs
+++ b/src/income_table.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::rc::Rc;
-use std::str::FromStr;
 use bigdecimal::BigDecimal;
 use chrono::{Local, NaiveDate};
 use cursive::Cursive;
@@ -10,7 +9,7 @@ use cursive_table_view::{TableView, TableViewItem};
 
 use crate::models;
 use crate::repositories::IncomeRepo;
-use crate::ui_helpers::toggle_buttons_visible;
+use crate::ui_helpers::{format_currency, parse_currency, toggle_buttons_visible};
 
 // Button name constants
 const INCOME_EDIT_BUTTON: &str = "income_table_edit_button";
@@ -47,7 +46,7 @@ impl TableViewItem<BasicColumn> for IncomeDisplay {
     fn to_column(&self, column: BasicColumn) -> String {
         match column {
             BasicColumn::Date => self.date.format("%d/%m/%Y").to_string(),
-            BasicColumn::Amount => self.amount.to_string(),
+            BasicColumn::Amount => format_currency(&self.amount),
         }
     }
 
@@ -141,7 +140,7 @@ fn income_form(siv: &mut Cursive, existing: Option<IncomeDisplay>, income_repo: 
 
     let amount_value = existing
         .as_ref()
-        .map(|i| i.amount.to_string())
+        .map(|i| format_currency(&i.amount))
         .unwrap_or_default();
     
     let notes_value = existing
@@ -170,7 +169,7 @@ fn income_form(siv: &mut Cursive, existing: Option<IncomeDisplay>, income_repo: 
 
                 // Validate date format DD/MM/YYYY
                 let parsed_date = NaiveDate::parse_from_str(&date_str, "%d/%m/%Y");
-                let amount_bd = BigDecimal::from_str(&amount_str);
+                let amount_bd = parse_currency(&amount_str);
 
                 if parsed_date.is_err() {
                     s.add_layer(Dialog::info("Invalid date format. Use DD/MM/YYYY"));

--- a/src/ledger_detail.rs
+++ b/src/ledger_detail.rs
@@ -11,7 +11,7 @@ use diesel::prelude::*;
 use crate::models;
 use crate::schema;
 use crate::repositories::ledger_repo::LedgerRepo;
-use crate::ui_helpers::toggle_buttons_visible;
+use crate::ui_helpers::{format_currency, parse_currency, toggle_buttons_visible};
 
 // Helper function to calculate bill due date for a ledger
 // If bill's day-of-month in ledger's month is before ledger date, advance to next month
@@ -74,7 +74,7 @@ impl TableViewItem<BillColumn> for LedgerBillDisplay {
     fn to_column(&self, column: BillColumn) -> String {
         match column {
             BillColumn::Name => self.bill_name.clone(),
-            BillColumn::Amount => format!("${}", self.amount),
+            BillColumn::Amount => format_currency(&self.amount),
             BillColumn::DueDay => self.due_day.clone(),
             BillColumn::Paid => if self.is_payed { "✓" } else { "" }.to_string(),
         }
@@ -94,7 +94,7 @@ impl TableViewItem<IncomeColumn> for IncomeDisplay {
     fn to_column(&self, column: IncomeColumn) -> String {
         match column {
             IncomeColumn::Date => self.date.clone(),
-            IncomeColumn::Amount => format!("${}", self.amount),
+            IncomeColumn::Amount => format_currency(&self.amount),
         }
     }
 
@@ -194,27 +194,27 @@ pub fn show_ledger_detail(siv: &mut Cursive, target_ledger_id: i32, ledger_repo:
     };
     
     let summary_text = format!(
-        "Bank Balance: ${}\n\
-         Income: ${} ({} items)\n\
-         Available Funds: ${}\n\n\
+        "Bank Balance: {}\n\
+         Income: {} ({} items)\n\
+         Available Funds: {}\n\n\
          BILLS         PLANNED     PAID\n\
          ─────────────────────────────\n\
-         Amount        ${}    ${}\n\
+         Amount        {}    {}\n\
          Count         {}          {}\n\n\
-         Total Expenses: ${}\n\n\
+         Total Expenses: {}\n\n\
          ───────────────────────────────\n\
-         Net: ${}\n\
+         Net: {}\n\
          {}",
-        ledger.bank_balance,
-        ledger.income,
+        format_currency(&ledger.bank_balance),
+        format_currency(&ledger.income),
         income_count,
-        ledger.total.unwrap_or(BigDecimal::from(0)),
-        unpaid_bills_amount,
-        paid_bills_amount,
+        format_currency(&ledger.total.unwrap_or(BigDecimal::from(0))),
+        format_currency(&unpaid_bills_amount),
+        format_currency(&paid_bills_amount),
         unpaid_bills_count,
         paid_bills_count,
-        ledger.expenses,
-        ledger.net.unwrap_or(BigDecimal::from(0)),
+        format_currency(&ledger.expenses),
+        format_currency(&ledger.net.unwrap_or(BigDecimal::from(0))),
         notes_section
     );
 
@@ -311,7 +311,7 @@ fn add_income_to_ledger(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<Ledg
 
     let mut select = SelectView::new();
     for income in month_incomes {
-        let label = format!("{} - ${}", income.date.format("%d/%m/%Y"), income.amount);
+        let label = format!("{} - {}", income.date.format("%d/%m/%Y"), format_currency(&income.amount));
         select.add_item(label, income.id);
     }
 
@@ -403,7 +403,7 @@ fn add_bill_to_ledger(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<Ledger
     let mut select = SelectView::new();
     for bill in available_bills {
         let due_day_str = bill.due_day.map_or("-".to_string(), |d| d.format("%-d").to_string());
-        let label = format!("{} - ${} - {}", bill.name, bill.amount, due_day_str);
+        let label = format!("{} - {} - {}", bill.name, format_currency(&bill.amount), due_day_str);
         select.add_item(label, (bill.id, bill.amount, bill.due_day, bill.is_auto_pay));
     }
 
@@ -495,7 +495,7 @@ fn edit_ledger_bill(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<LedgerRe
 
         let form = ListView::new()
             .child("Amount", EditView::new()
-                .content(bill.amount.to_string())
+                .content(format_currency(&bill.amount))
                 .with_name("edit_bill_amount")
                 .fixed_width(20))
             .child("Due Day (DD/MM)", EditView::new()
@@ -532,7 +532,7 @@ fn edit_ledger_bill(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<LedgerRe
                     }).unwrap();
 
                     // Parse amount
-                    let amount = match amount_str.to_string().parse::<BigDecimal>() {
+                    let amount = match parse_currency(&amount_str) {
                         Ok(a) => a,
                         Err(_) => {
                             s.add_layer(Dialog::info("Invalid amount format"));
@@ -571,7 +571,7 @@ fn edit_ledger_bill(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<LedgerRe
 fn update_ledger(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<LedgerRepo>) {
     let ledger = ledger_repo.find_by_id(ledger_id).expect("Error loading ledger");
 
-    let current_balance = ledger.bank_balance.to_string();
+    let current_balance = format_currency(&ledger.bank_balance);
     let name = ledger.name.unwrap_or_default();
     let date = ledger.date;
     let notes = ledger.notes.unwrap_or_default();
@@ -623,7 +623,7 @@ fn update_ledger(siv: &mut Cursive, ledger_id: i32, ledger_repo: &Rc<LedgerRepo>
                 return;
             }
 
-            let balance = new_balance.to_string().parse::<BigDecimal>();
+            let balance = parse_currency(&new_balance);
 
             if balance.is_err() {
                 s.add_layer(Dialog::info("Invalid balance format"));

--- a/src/ledger_table.rs
+++ b/src/ledger_table.rs
@@ -11,7 +11,7 @@ use diesel::prelude::*;
 use crate::models;
 use crate::repositories::ledger_repo::LedgerRepo;
 use crate::db::PgConnector;
-use crate::ui_helpers::toggle_buttons_visible;
+use crate::ui_helpers::{format_currency, toggle_buttons_visible};
 use crate::ledger_detail::calculate_bill_due_date;
 
 // Button name constants
@@ -64,11 +64,11 @@ impl TableViewItem<BasicColumn> for LedgerDisplay {
     fn to_column(&self, column: BasicColumn) -> String {
         match column {
             BasicColumn::Date => self.date.format("%d/%m/%Y").to_string(),
-            BasicColumn::BankBalance => format!("${}", self.bank_balance),
-            BasicColumn::Income => format!("${}", self.income),
-            BasicColumn::Expenses => format!("${}", self.expenses),
-            BasicColumn::Net => format!("${}", self.net),
-            BasicColumn::Total => format!("${}", self.total),
+            BasicColumn::BankBalance => format_currency(&self.bank_balance),
+            BasicColumn::Income => format_currency(&self.income),
+            BasicColumn::Expenses => format_currency(&self.expenses),
+            BasicColumn::Net => format_currency(&self.net),
+            BasicColumn::Total => format_currency(&self.total),
             BasicColumn::Name => self.name.clone(),
         }
     }

--- a/src/ui_helpers.rs
+++ b/src/ui_helpers.rs
@@ -1,10 +1,127 @@
+use std::str::FromStr;
+use bigdecimal::BigDecimal;
 use cursive::Cursive;
 use cursive::views::{Button, HideableView};
+use rusty_money::{iso, Money};
 
 pub fn toggle_buttons_visible(siv: &mut Cursive, item_count: usize, button_names: &[&str]) {
     for name in button_names {
         siv.call_on_name(name, |v: &mut HideableView<Button>| {
             v.set_visible(item_count > 0);
         });
+    }
+}
+
+/// Formats a `BigDecimal` amount as a standard USD currency string using rusty-money.
+pub fn format_currency(amount: &BigDecimal) -> String {
+    let rounded = amount.round(2);
+    let money = Money::from_str(&rounded.to_string(), iso::USD)
+        .unwrap_or_else(|_| Money::from_minor(0, iso::USD));
+    money.to_string()
+}
+
+/// Parses a user-input currency string into a `BigDecimal`.
+/// Strips currency symbols, parentheses, and whitespace, delegating numeric and comma parsing to `rusty_money`.
+pub fn parse_currency(input: &str) -> Result<BigDecimal, String> {
+    let mut s = input.trim();
+    if s.is_empty() {
+        return Err("Input cannot be empty".to_string());
+    }
+
+    let mut is_negative = false;
+
+    // Handle accounting parentheses notation e.g. ($1,234.56) or (1234.56)
+    if s.starts_with('(') && s.ends_with(')') && s.len() >= 2 {
+        is_negative = true;
+        s = &s[1..s.len() - 1];
+    }
+
+    // Strip $, spaces, and handle trailing minus e.g. 100-
+    let mut cleaned: String = s.chars().filter(|c| *c != '$' && !c.is_whitespace()).collect();
+    if let Some(stripped) = cleaned.strip_suffix('-') {
+        is_negative = !is_negative;
+        cleaned = stripped.to_string();
+    }
+
+    if cleaned.is_empty() {
+        return Err("Invalid amount format".to_string());
+    }
+
+    let money = Money::from_str(&cleaned, iso::USD)
+        .map_err(|e| format!("Invalid amount format: {:?}", e))?;
+
+    let mut bd = BigDecimal::from_str(&money.amount().to_string())
+        .map_err(|e| format!("Invalid amount format: {}", e))?;
+
+    if is_negative {
+        bd = -bd;
+    }
+
+    Ok(bd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_currency_basic() {
+        assert_eq!(format_currency(&BigDecimal::from(0)), "$0.00");
+        assert_eq!(format_currency(&BigDecimal::from(100)), "$100.00");
+        assert_eq!(format_currency(&BigDecimal::from(1000)), "$1,000.00");
+        assert_eq!(format_currency(&BigDecimal::from(1000000)), "$1,000,000.00");
+    }
+
+    #[test]
+    fn test_format_currency_decimals() {
+        assert_eq!(format_currency(&BigDecimal::from_str("1234.5").unwrap()), "$1,234.50");
+        assert_eq!(format_currency(&BigDecimal::from_str("1234.56").unwrap()), "$1,234.56");
+        assert_eq!(format_currency(&BigDecimal::from_str("1234.567").unwrap()), "$1,234.57");
+        assert_eq!(format_currency(&BigDecimal::from_str("0.5").unwrap()), "$0.50");
+        assert_eq!(format_currency(&BigDecimal::from_str("0.05").unwrap()), "$0.05");
+    }
+
+    #[test]
+    fn test_format_currency_negative() {
+        assert_eq!(format_currency(&BigDecimal::from(-100)), "-$100.00");
+        assert_eq!(format_currency(&BigDecimal::from_str("-1234.56").unwrap()), "-$1,234.56");
+        assert_eq!(format_currency(&BigDecimal::from_str("-0.00").unwrap()), "$0.00");
+    }
+
+    #[test]
+    fn test_parse_currency_standard() {
+        assert_eq!(parse_currency("100").unwrap(), BigDecimal::from(100));
+        assert_eq!(parse_currency("100.50").unwrap(), BigDecimal::from_str("100.50").unwrap());
+        assert_eq!(parse_currency("1,000.50").unwrap(), BigDecimal::from_str("1000.50").unwrap());
+        assert_eq!(parse_currency("1,000,000.00").unwrap(), BigDecimal::from_str("1000000.00").unwrap());
+    }
+
+    #[test]
+    fn test_parse_currency_with_dollar_and_spaces() {
+        assert_eq!(parse_currency("$100").unwrap(), BigDecimal::from(100));
+        assert_eq!(parse_currency(" $ 1,234.56 ").unwrap(), BigDecimal::from_str("1234.56").unwrap());
+        assert_eq!(parse_currency("$1,000").unwrap(), BigDecimal::from(1000));
+        assert_eq!(parse_currency("1,000$").unwrap(), BigDecimal::from(1000));
+    }
+
+    #[test]
+    fn test_parse_currency_negative() {
+        assert_eq!(parse_currency("-100").unwrap(), BigDecimal::from(-100));
+        assert_eq!(parse_currency("-$1,234.56").unwrap(), BigDecimal::from_str("-1234.56").unwrap());
+        assert_eq!(parse_currency("$-1,234.56").unwrap(), BigDecimal::from_str("-1234.56").unwrap());
+        assert_eq!(parse_currency("($1,234.56)").unwrap(), BigDecimal::from_str("-1234.56").unwrap());
+        assert_eq!(parse_currency("(1,234.56)").unwrap(), BigDecimal::from_str("-1234.56").unwrap());
+        assert_eq!(parse_currency("100-").unwrap(), BigDecimal::from(-100));
+    }
+
+    #[test]
+    fn test_parse_currency_invalid() {
+        assert!(parse_currency("").is_err());
+        assert!(parse_currency("   ").is_err());
+        assert!(parse_currency("$").is_err());
+        assert!(parse_currency("abc").is_err());
+        assert!(parse_currency("1.2.3").is_err());
+        assert!(parse_currency(".").is_err());
+        assert!(parse_currency("$.").is_err());
     }
 }


### PR DESCRIPTION
Resolves #40

**Changes:**
- Introduced `rusty-money` crate for handling USD currency parsing and formatting.
- Updated `format_currency` helper to handle comma insertion and strict 2-decimal rounding.
- Updated `parse_currency` helper to securely sanitize user inputs (e.g. stripping `$`, handling accounting negatives like `($100)`, and removing commas) before parsing to `BigDecimal`.
- Implemented formatted values across all table views (Ledgers, Bills, Income) and detail views.
- Verified parsing behaviors thoroughly with unit tests.