### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "money-bae"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "money-bae"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Bumps version to 0.9.2 following the currency formatting feature merge.